### PR TITLE
Implement first permissible or none strategy for node colouring.

### DIFF
--- a/listcolouring/__init__.py
+++ b/listcolouring/__init__.py
@@ -51,6 +51,20 @@ def first_permissible_or_none(G, u, v):
         choice = None
     return(choice)
 
+def first_permissible_or_none_node(G, u):
+    """ Returns the first element of A = P - X if A is non-empty otherwise returns None.
+        X is the list of colours on neighbours of u.
+        P is the list of permissible colours for node u.
+    """
+    X = colours_on_neighbours(G, u)
+    P = set(G.nodes[u]["permissible"])
+    choices = P - X
+    if(len(choices) > 0):
+        choice = list(choices)[0]
+    else:
+        choice = None
+    return(choice)
+
 def greedy_list_edge_colouring(G):
     """Assign the first permissible colour to every edge (or None if all permissible
     colours already used on incident edges)."""
@@ -65,4 +79,4 @@ def print_list_edge_colouring(G):
             perm = eattr['permissible']
             col = eattr['colour']
             print(f"({n}, {nbr}, {perm}, {col})")
-        
+

--- a/tests/test_first-permissible-or-none-node.py
+++ b/tests/test_first-permissible-or-none-node.py
@@ -7,6 +7,7 @@ def test_first_permissible_or_none_node():
     G = nx.complete_graph(3)
     permissible_dict = {0: [0, 1], 1: [1, 2], 2: [2, 3]}
     nx.set_node_attributes(G, permissible_dict, "permissible")
+    nx.set_node_attributes(G, None, "colour")
     assert first_permissible_or_none_node(G, 0) == 0
     assert first_permissible_or_none_node(G, 1) == 1
-    assert first_permissible_or_node_node(G, 2) == 2
+    assert first_permissible_or_none_node(G, 2) == 2

--- a/tests/test_first-permissible-or-none-node.py
+++ b/tests/test_first-permissible-or-none-node.py
@@ -1,0 +1,12 @@
+import networkx as nx
+
+import listcolouring
+from listcolouring import first_permissible_or_none_node
+
+def test_first_permissible_or_none_node():
+    G = nx.complete_graph(3)
+    permissible_dict = {0: [0, 1], 1: [1, 2], 2: [2, 3]}
+    nx.set_node_attributes(G, permissible_dict, "permissible")
+    assert first_permissible_or_none_node(G, 0) == 0
+    assert first_permissible_or_none_node(G, 1) == 1
+    assert first_permissible_or_node_node(G, 2) == 2


### PR DESCRIPTION
Add function `first_permissible_or_none_node(G, u)` with tests. Tests currently failing.

```
===================================================== FAILURES =====================================================
_______________________________________ test_first_permissible_or_none_node ________________________________________

    def test_first_permissible_or_none_node():
        G = nx.complete_graph(3)
        permissible_dict = {0: [0, 1], 1: [1, 2], 2: [2, 3]}
        nx.set_node_attributes(G, permissible_dict, "permissible")
>       assert first_permissible_or_none_node(G, 0) == 0

tests/test_first-permissible-or-none-node.py:10:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
listcolouring/__init__.py:59: in first_permissible_or_none_node
    X = colours_on_neighbours(G, u)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

G = <networkx.classes.graph.Graph object at 0x7de7bd8d4920>, n = 0

    def colours_on_neighbours(G, n):
        """The set of all colours on neighbours of a node n in a graph G."""
>       return(set([nx.get_node_attributes(G, "colour")[m] for m in G.neighbors(n)]))
E       KeyError: 1

listcolouring/__init__.py:34: KeyError
============================================= short test summary info ==============================================
FAILED tests/test_first-permissible-or-none-node.py::test_first_permissible_or_none_node - KeyError: 1
=========================================== 1 failed, 3 passed in 0.18s ============================================
make: *** [Makefile:5: test] Error 1